### PR TITLE
Use python from env rather than specify one.

### DIFF
--- a/bin/yaml2sh
+++ b/bin/yaml2sh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Read in a YAML-formatted file, either named on the command-line or supplied


### PR DESCRIPTION
This script currently specifies which of your systems pythons it wants to use.

For MacOS users, this python specified in the one that comes with the OS.

Lots of developers using macs prefer to manage packages with something like Homebrew, which puts python in other places and makes them accessible by adding their path to $PATH, but keeps all the system default stuff intact so it's available for system apps etc.

This commit sets the script to use whatever python has been selected by the current environment—so gives developers more control of which python they want to use.

I came across this issue because after updating to macOS Sierra my system python was missing the yaml module.

```
Traceback (most recent call last):
  File "/Users/Luke/git/alaveteli/commonlib/bin/yaml2sh", line 9, in <module>
    import optparse, sys, re, yaml
  ImportError: No module named yaml
    : shlib/deployfns read_conf: error loading config file config/general.yml
```

Let me know if there's a better way to improve this :)